### PR TITLE
Right stop

### DIFF
--- a/lib/rb-fsevent/fsevent.rb
+++ b/lib/rb-fsevent/fsevent.rb
@@ -28,7 +28,8 @@ class FSEvent
   end
 
   def run
-    while !pipe.eof?
+    @running = true
+    while @running && !pipe.eof?
       if line = pipe.readline
         modified_dir_paths = line.split(":").select { |dir| dir != "\n" }
         callback.call(modified_dir_paths)
@@ -46,7 +47,7 @@ class FSEvent
     end
   rescue IOError
   ensure
-    @pipe = false
+    @running = false
   end
 
   if RUBY_VERSION < '1.9'


### PR DESCRIPTION
Hello!

Small typical example:

```
require 'rb-fsevent'
fsevent = FSEvent.new

fsevent.watch(".") { |e|
  puts e.inspect
  fsevent.stop 
}

fsevent.run
```

Now it doesn't work, we are creating new pipe every time, then call #stop from callbacks ;)
