### PR TITLE
[fsevent_watch_guard] Support 32bit kernels

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -27,6 +27,9 @@ else
 
   cflags = core_flags + %w{-Os -pipe}
 
+  arch_sig = `uname -m`
+  cflags << '-arch i386'  if arch_sig =~ /i386$/i
+
   wflags = %w{
     -Wmissing-prototypes -Wreturn-type -Wmissing-braces -Wparentheses -Wswitch
     -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable


### PR DESCRIPTION
Copied from: https://github.com/guard/guard/pull/206

Running Mac OS X 10.6.8 on a MacBook1,1

```
 > uname -a
Darwin mobile 10.8.0 Darwin Kernel Version 10.8.0: Tue Jun  7 16:33:36 PDT 2011; root:xnu-1504.15.3~1/RELEASE_I386 i386
```
### Current rb-fsevent

```
 > gem install guard
Fetching: guard-0.9.4.gem (100%)
Successfully installed guard-0.9.4
1 gem installed
```

```
 > guard
[...]
~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/lib/vendor/darwin/lib/rb-fsevent/fsevent.rb:89:in `popen': Bad CPU type in executable - ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/bin/fsevent_watch_guard (Errno::E086)
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/lib/vendor/darwin/lib/rb-fsevent/fsevent.rb:89:in `pipe'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/lib/vendor/darwin/lib/rb-fsevent/fsevent.rb:46:in `stop'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/lib/vendor/darwin/lib/rb-fsevent/fsevent.rb:42:in `ensure in run'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/lib/vendor/darwin/lib/rb-fsevent/fsevent.rb:42:in `run'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/lib/guard/listeners/darwin.rb:18:in `start'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/lib/guard.rb:202:in `start'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/lib/guard/cli.rb:74:in `start'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
  from ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/bin/guard:6:in `<top (required)>'
  from ~/.rbenv/versions/1.9.2-p290/bin/guard:19:in `load'
  from ~/.rbenv/versions/1.9.2-p290/bin/guard:19:in `<main>'
```

```
 > file ~/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/bin/fsevent_watch_guard
/Users/johannesh/.rbenv/versions/1.9.2-p290/lib/ruby/gems/1.9.1/gems/guard-0.9.4/bin/fsevent_watch_guard: Mach-O 64-bit executable x86_64
```
### Patched rb-fsevent

```
 > rake install
guard 0.9.4 built to pkg/guard-0.9.4.gem
guard (0.9.4) installed
```

```
 > guard
[...]
0 scenarios
0 steps
0m0.000s
```

Runs just fine now, all specs pass :)
