### PR TITLE
Allow FSEvent.watch calls to be chained

### DIFF
--- a/lib/rb-fsevent/fsevent.rb
+++ b/lib/rb-fsevent/fsevent.rb
@@ -25,6 +25,8 @@ class FSEvent
     else
       @options  = []
     end
+
+    self
   end
 
   def run

--- a/spec/rb-fsevent/fsevent_spec.rb
+++ b/spec/rb-fsevent/fsevent_spec.rb
@@ -10,6 +10,10 @@ describe FSEvent do
     end
   end
 
+  it "should allow watch calls to be chained" do
+    @fsevent.watch(@fixture_path).should respond_to(:watch)
+  end
+
   it "should have a watcher_path that resolves to an executable file" do
     File.exists?(FSEvent.watcher_path).should be_true
     File.executable?(FSEvent.watcher_path).should be_true


### PR DESCRIPTION
Hi,

This means I can rewrite this

```
FSEvent.new.tap {|fsevent|
  fsevent.watch('.git', &block)
  fsevent.run
}
```

Like this

```
FSEvent.new.watch('.git', &block).run
```

What do you think?
