### PR TITLE
Quote path to fsevent_watch bin.

### DIFF
--- a/lib/rb-fsevent/fsevent.rb
+++ b/lib/rb-fsevent/fsevent.rb
@@ -60,7 +60,7 @@ class FSEvent
 
   if RUBY_VERSION < '1.9'
     def open_pipe
-      IO.popen("#{self.class.watcher_path} #{options_string} #{shellescaped_paths}")
+      IO.popen("'#{self.class.watcher_path}' #{options_string} #{shellescaped_paths}")
     end
 
     private


### PR DESCRIPTION
Hi @thibaudgg

This fixes issue where a space in the path to the bin would cause it to crap out. This is an issue when bundling it up for distribution when using the gem in a .app (for example).

thanks!
