### PR TITLE
Fix race condition in stopping FSEvent runner

### DIFF
--- a/lib/rb-fsevent/fsevent.rb
+++ b/lib/rb-fsevent/fsevent.rb
@@ -43,7 +43,7 @@ class FSEvent
         callback.call(modified_dir_paths)
       end
     end
-  rescue Interrupt, IOError
+  rescue Interrupt, IOError, Errno::EBADF
   ensure
     stop
   end


### PR DESCRIPTION
The race condition is the following. When a FSEvent#stop is called, it
kills the child process and closes the pipe. It can happen that the kill
signal is sent and then succesfully the pipe is closed, before the child
process dies and the pipe in the parent is closed.

This means that IO::select() can raise a Errno::EBADF if the file
descriptor is closed while waiting in select(). This additional rescue
makes sure we shutdown in this case just like any others. This is a much
more reliable solution than adding for example a sleep() between
Process.kill and @pipe.close in FSEvent#stop.

Found because of https://github.com/rubinius/rubinius/issues/2102.
