### PR TITLE
Fix a bug in jruby env where pid is not a valid pid. 

### DIFF
--- a/lib/rb-fsevent/fsevent.rb
+++ b/lib/rb-fsevent/fsevent.rb
@@ -52,12 +52,21 @@ class FSEvent
 
   def stop
     unless @pipe.nil?
-      Process.kill('KILL', @pipe.pid)
+      Process.kill('KILL', @pipe.pid) if process_running?(pid)
       @pipe.close
     end
   rescue IOError
   ensure
     @running = false
+  end
+
+  def process_running?(pid)
+    begin
+      Process.kill(0, pid)
+      true
+    rescue Errno::ESRCH
+      false
+    end
   end
 
   if RUBY_VERSION < '1.9'

--- a/lib/rb-fsevent/fsevent.rb
+++ b/lib/rb-fsevent/fsevent.rb
@@ -52,7 +52,7 @@ class FSEvent
 
   def stop
     unless @pipe.nil?
-      Process.kill('KILL', @pipe.pid) if process_running?(pid)
+      Process.kill('KILL', @pipe.pid) if process_running?(@pipe.pid)
       @pipe.close
     end
   rescue IOError


### PR DESCRIPTION
causing JVM/Jruby kernel errors on sigterm/sigint. Before calling Process.kill('KILL', pid) we need to gracefully check if the process is avaialble - if its not we can just close the pipe