### PR TITLE
Limit Rake to v10 for RSpec 2.99 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rake'
+gem 'rake', '~> 10.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem 'rake', '~> 10.0'
-

--- a/rb-fsevent.gemspec
+++ b/rb-fsevent.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',     '~> 1.0'
   s.add_development_dependency 'rspec',       '~> 2.11'
   s.add_development_dependency 'guard-rspec', '~> 4.2'
+  s.add_development_dependency 'rake',        '~> 10.0'
 end


### PR DESCRIPTION
RSpec 2.99 uses the Rake method #last_comment, which is deprecated in
v11, and finally removed in v12.
RSpec 2.99 also has a development dependency on Rake v10, so this limit
seems like a reasonable choice for the moment.