### PR TITLE
Update RSpec and Rake

### DIFF
--- a/rb-fsevent.gemspec
+++ b/rb-fsevent.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',     '~> 1.0'
   s.add_development_dependency 'rspec',       '~> 3.6'
   s.add_development_dependency 'guard-rspec', '~> 4.2'
-  s.add_development_dependency 'rake',        '~> 10.0'
+  s.add_development_dependency 'rake',        '~> 12.0'
 end

--- a/rb-fsevent.gemspec
+++ b/rb-fsevent.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_development_dependency 'bundler',     '~> 1.0'
-  s.add_development_dependency 'rspec',       '~> 2.11'
+  s.add_development_dependency 'rspec',       '~> 3.6'
   s.add_development_dependency 'guard-rspec', '~> 4.2'
   s.add_development_dependency 'rake',        '~> 10.0'
 end

--- a/spec/rb-fsevent/fsevent_spec.rb
+++ b/spec/rb-fsevent/fsevent_spec.rb
@@ -12,20 +12,20 @@ describe FSEvent do
 
   it "shouldn't pass anything to watch when instantiated without a path" do
     fsevent = FSEvent.new
-    fsevent.paths.should be_nil
-    fsevent.callback.should be_nil
+    expect(fsevent.paths).to be_nil
+    expect(fsevent.callback).to be_nil
   end
 
   it "should pass path and block to watch when instantiated with them" do
     blk = proc { }
     fsevent = FSEvent.new(@fixture_path, &blk)
-    fsevent.paths.should == [@fixture_path]
-    fsevent.callback.should == blk
+    expect(fsevent.paths).to eq([@fixture_path])
+    expect(fsevent.callback).to eq(blk)
   end
 
   it "should have a watcher_path that resolves to an executable file" do
-    File.exists?(FSEvent.watcher_path).should be true
-    File.executable?(FSEvent.watcher_path).should be true
+    expect(File.exists?(FSEvent.watcher_path)).to be true
+    expect(File.executable?(FSEvent.watcher_path)).to be true
   end
 
   it "should work with path with an apostrophe" do
@@ -35,12 +35,12 @@ describe FSEvent do
     @fsevent.watch custom_path.to_s do |paths|
       @results += paths
     end
-    @fsevent.paths.should == ["#{custom_path}"]
+    expect(@fsevent.paths).to eq(["#{custom_path}"])
     run
     FileUtils.touch file
     stop
     File.delete file
-    @results.should == [custom_path.to_s + '/']
+    expect(@results).to eq([custom_path.to_s + '/'])
   end
 
   it "should catch new file" do
@@ -50,28 +50,28 @@ describe FSEvent do
     FileUtils.touch file
     stop
     File.delete file
-    @results.should == [@fixture_path.to_s + '/']
+    expect(@results).to eq([@fixture_path.to_s + '/'])
   end
 
   it "should catch file update" do
     file = @fixture_path.join("folder1/file1.txt")
-    File.exists?(file).should be true
+    expect(File.exists?(file)).to be true
     run
     FileUtils.touch file
     stop
-    @results.should == [@fixture_path.join("folder1/").to_s]
+    expect(@results).to eq([@fixture_path.join("folder1/").to_s])
   end
 
   it "should catch files update" do
     file1 = @fixture_path.join("folder1/file1.txt")
     file2 = @fixture_path.join("folder1/folder2/file2.txt")
-    File.exists?(file1).should be true
-    File.exists?(file2).should be true
+    expect(File.exists?(file1)).to be true
+    expect(File.exists?(file2)).to be true
     run
     FileUtils.touch file1
     FileUtils.touch file2
     stop
-    @results.should == [@fixture_path.join("folder1/").to_s, @fixture_path.join("folder1/folder2/").to_s]
+    expect(@results).to eq([@fixture_path.join("folder1/").to_s, @fixture_path.join("folder1/folder2/").to_s])
   end
 
   def run

--- a/spec/rb-fsevent/fsevent_spec.rb
+++ b/spec/rb-fsevent/fsevent_spec.rb
@@ -24,8 +24,8 @@ describe FSEvent do
   end
 
   it "should have a watcher_path that resolves to an executable file" do
-    File.exists?(FSEvent.watcher_path).should be_true
-    File.executable?(FSEvent.watcher_path).should be_true
+    File.exists?(FSEvent.watcher_path).should be true
+    File.executable?(FSEvent.watcher_path).should be true
   end
 
   it "should work with path with an apostrophe" do
@@ -55,7 +55,7 @@ describe FSEvent do
 
   it "should catch file update" do
     file = @fixture_path.join("folder1/file1.txt")
-    File.exists?(file).should be_true
+    File.exists?(file).should be true
     run
     FileUtils.touch file
     stop
@@ -65,8 +65,8 @@ describe FSEvent do
   it "should catch files update" do
     file1 = @fixture_path.join("folder1/file1.txt")
     file2 = @fixture_path.join("folder1/folder2/file2.txt")
-    File.exists?(file1).should be_true
-    File.exists?(file2).should be_true
+    File.exists?(file1).should be true
+    File.exists?(file2).should be true
     run
     FileUtils.touch file1
     FileUtils.touch file2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ require 'rspec'
 require 'rb-fsevent'
 
 RSpec.configure do |config|
-  config.color_enabled = true
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
   


### PR DESCRIPTION
My immediate reason for the upgrade was that the 'bundle exec rake spec' was having a problem finding the right rspec path. Doing to the latest version of rspec seems to resolve the problem.