### PR TITLE
Add configuration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+sudo: false
+before_install:
+  - gem install bundler
+  - gem update bundler
+rvm:
+  - 2.4.1
+  - jruby-1.7.26
+  - jruby-9.1.8.0
+  - rbx-3.72
+matrix:
+  allow_failures:
+    - rvm: rbx-3.72
+os:
+  - osx
+osx_image: xcode9


### PR DESCRIPTION
Since Travis now has support for OSX images, it might be helpful to get the CI tests running with it.
I am also going to have a look at [wwtd](https://github.com/grosser/wwtd) (what would travis do?) and see if that might be useful to running the same tests locally