### PR TITLE
Add source code link to gemspec

### DIFF
--- a/rb-fsevent.gemspec
+++ b/rb-fsevent.gemspec
@@ -13,6 +13,10 @@ Gem::Specification.new do |s|
   s.description = 'FSEvents API with Signals catching (without RubyCocoa)'
   s.license     = 'MIT'
 
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/thibaudgg/rb-fsevent'
+  }
+
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   s.require_path = 'lib'
 


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for `rb-fsevent`, using the rubygems API. More details on the direction of travel for gemspecs is [here](https://github.com/rubygems/rubygems.org/issues/1127) and [here](https://github.com/rubygems/rubygems.org/pull/1234), and the current state is [here](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb).

(My interest in this is so that [Dependabot](https://dependabot.com) can find a link to the `rb-fsevent` source code when it creates PRs.)