### PR TITLE
Update the "full event information" example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ fsevent.run
 require 'rb-fsevent'
 fsevent = FSEvent.new
 fsevent.watch Dir.pwd do |paths, event_meta|
-  event_meta.events.each do |event|
-    puts "event ID: #{event.id}"
-    puts "path: #{event.path}"
-    puts "c flags: #{event.cflags}"
-    puts "named flags: #{event.flags.join(', ')}"
+  event_meta['events'].each do |event|
+    puts "event ID: #{event['id']}"
+    puts "path: #{event['path']}"
+    puts "c flags: #{event['cflags']}"
+    puts "named flags: #{event['flags'].join(', ')}"
     # named flags will include strings such as `ItemInodeMetaMod` or `OwnEvent`
   end
 end


### PR DESCRIPTION
`event_meta` and the events themselves are hashes with string keys, not objects with attributes.