### PR TITLE
Remove bundler development dependency

### DIFF
--- a/rb-fsevent.gemspec
+++ b/rb-fsevent.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   s.require_path = 'lib'
 
-  s.add_development_dependency 'bundler',     '~> 1.0'
   s.add_development_dependency 'rspec',       '~> 3.6'
   s.add_development_dependency 'guard-rspec', '~> 4.2'
   s.add_development_dependency 'rake',        '~> 12.0'


### PR DESCRIPTION
We are currently in the [process](https://github.com/chef/chef-workstation/pull/1123) of updating our package to use Ruby 2.7 which switched to using Bundler 2.x. We don't want to keep including bundler 1.x inside the package we generate so we have started going through and removing development dependencies on bundler.

This works for us because all recent versions of Ruby include bundler (`gem install bundler` is unnecessary). `bundle install` in this directory still works. Our companies Ruby development has started removing bundler as a dev dependency to make the upgrade to Ruby 2.7 easier.

Another option would be to remove the version specification, but that does cause a warning when doing `gem build`:
```
$ gem build rb-fsevent.gemspec
WARNING:  open-ended dependency on bundler (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```
This is just a warning, but it is an annoying one.

What would you think of either of these solutions?