### PR TITLE
Add GitHub Actions for Ruby 3.1 - 3.4.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  MACOSX_DEPLOYMENT_TARGET: '14.0'
+
+jobs:
+  build:
+    name: Ruby ${{ matrix.ruby }} Specs
+    runs-on: macos-14
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 15.0.1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version:  ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/rb-fsevent.gemspec
+++ b/rb-fsevent.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec',       '~> 3.6'
   s.add_development_dependency 'guard-rspec', '~> 4.2'
-  s.add_development_dependency 'rake',        '~> 12.0'
+  s.add_development_dependency 'rake',        '~> 13.0'
 end


### PR DESCRIPTION
- update rake to support newer Rubies
- example run https://github.com/RubyElders/rb-fsevent/actions/runs/14228187030

I have selected macosx14.0 SDK combined with XCode 15.0.1 and MacOS 14 runner. Feel free to if more combinations are welcomed, I can add them to build matrix.